### PR TITLE
Add support for most recent search type

### DIFF
--- a/src/historical.ts
+++ b/src/historical.ts
@@ -189,7 +189,7 @@ export function queryAndCountOrderedEvent(
  * @param options - Rules engine options with event hash generation capability
  * @param from - Optional timestamp (in milliseconds) marking the start of the time range (default: 0)
  * @param to - Optional timestamp (in milliseconds) marking the end of the time range (default: Infinity)
- * @returns
+ * @returns the index of the most recent event. -1 if no event is found
  */
 export function queryAndCountMostRecentEvent(
   events: Array<HistoricalEvent>,

--- a/src/historical.ts
+++ b/src/historical.ts
@@ -209,11 +209,13 @@ export function queryAndCountMostRecentEvent(
           return mostRecent;
         }
 
-        const mostRecentTimestamp = contextEvent.timestamps
-          .filter((t: number) => t >= from && t <= to)
-          .pop();
+        const mostRecentTimestamp =
+          contextEvent.timestamps[contextEvent.timestamps.length - 1];
 
-        return mostRecentTimestamp && mostRecentTimestamp > mostRecent.timestamp
+        return mostRecentTimestamp &&
+          mostRecentTimestamp >= from &&
+          mostRecentTimestamp <= to &&
+          mostRecentTimestamp > mostRecent.timestamp
           ? { index, timestamp: mostRecentTimestamp }
           : mostRecent;
       },

--- a/src/historical.ts
+++ b/src/historical.ts
@@ -202,26 +202,22 @@ export function queryAndCountMostRecentEvent(
     return events.reduce(
       (mostRecent, event, index) => {
         const eventHash = options.generateEventHash(normalizeEvent(event));
-
         const contextEvent = context.events[eventHash];
-
         if (!contextEvent) {
           return mostRecent;
         }
 
-        const mostRecentTimestamp =
-          contextEvent.timestamps[contextEvent.timestamps.length - 1];
+        const mostRecentTimestamp = contextEvent.timestamps
+          .filter((t: number) => t >= from && t <= to)
+          .pop();
 
-        return mostRecentTimestamp &&
-          mostRecentTimestamp >= from &&
-          mostRecentTimestamp <= to &&
-          mostRecentTimestamp > mostRecent.timestamp
+        return mostRecentTimestamp && mostRecentTimestamp > mostRecent.timestamp
           ? { index, timestamp: mostRecentTimestamp }
           : mostRecent;
       },
-      { index: Infinity, timestamp: 0 },
+      { index: -1, timestamp: 0 },
     ).index;
   } catch {
-    return Infinity;
+    return -1;
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -29,6 +29,7 @@ import {
 import {
   checkForHistoricalMatcher,
   queryAndCountAnyEvent,
+  queryAndCountMostRecentEvent,
   queryAndCountOrderedEvent,
 } from "./historical";
 
@@ -163,7 +164,15 @@ export function createHistoricalDefinition(
     evaluate: (context, options) => {
       let eventCount: number;
 
-      if (SearchType.ORDERED === searchType) {
+      if (SearchType.MOST_RECENT === searchType) {
+        eventCount = queryAndCountMostRecentEvent(
+          events,
+          context,
+          options,
+          from,
+          to,
+        );
+      } else if (SearchType.ORDERED === searchType) {
         eventCount = queryAndCountOrderedEvent(
           events,
           context,

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -38,6 +38,7 @@ export const LogicType = {
 export const SearchType = {
   ANY: "any",
   ORDERED: "ordered",
+  MOST_RECENT: "mostRecent",
 };
 
 export type SupportedCondition =

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -34,6 +34,7 @@ export interface RuleSet {
 
 export interface Rule {
   key?: string;
+  meta?: object;
   condition: GroupCondition | MatcherCondition | HistoricalCondition;
   consequences: Array<Consequence>;
 }

--- a/test/historical-query.spec.ts
+++ b/test/historical-query.spec.ts
@@ -42,374 +42,575 @@ const CONSEQUENCE: Consequence = {
 };
 
 describe("rules from AJO", () => {
-  it("supports historical condition for searchType ANY", () => {
-    expect(
-      RulesEngine(
-        {
-          version: 1,
-          rules: [
-            {
-              condition: {
-                definition: {
-                  conditions: [
-                    {
-                      definition: {
-                        conditions: [
-                          {
-                            definition: {
-                              events: [
-                                {
-                                  "iam.eventType": "display",
-                                  "iam.id":
-                                    "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6",
-                                },
-                              ],
-                              matcher: "eq",
-                              value: 0,
-                              from: 1681321309855,
-                              to: 1996681309855,
-                            },
-                            type: "historical",
-                          },
-                        ],
-                        logic: "and",
-                      },
-                      type: "group",
-                    },
-                  ],
-                  logic: "and",
-                },
-                type: "group",
-              },
-              consequences: [CONSEQUENCE],
-            },
-          ],
-        },
-        rulesEngineOptions,
-      ).execute({
-        events: {
-          display: {
-            "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6":
+  describe("with searchType any", () => {
+    it("supports historical condition", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
               {
-                event: {
-                  "iam.eventType": "display",
-                  "iam.id":
-                    "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6",
-                },
-                firstTimestamp: 1695065771698,
-                timestamp: 1695065771698,
-                count: 0,
-              },
-          },
-        },
-      }),
-    ).toEqual([[CONSEQUENCE]]);
-  });
-
-  it("Should return empty consequence for historical condition when count doesn't match with matcher provided", () => {
-    expect(
-      RulesEngine(
-        {
-          version: 1,
-          rules: [
-            {
-              condition: {
-                definition: {
-                  conditions: [
-                    {
-                      definition: {
-                        conditions: [
-                          {
-                            definition: {
-                              events: [
-                                {
-                                  "iam.eventType": "display",
-                                  "iam.id":
-                                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
-                                },
-                              ],
-                              matcher: "eq",
-                              value: 0,
-                              from: 1681321309855,
-                              to: 1996681309855,
-                            },
-                            type: "historical",
-                          },
-                        ],
-                        logic: "and",
-                      },
-                      type: "group",
-                    },
-                  ],
-                  logic: "and",
-                },
-                type: "group",
-              },
-              consequences: [CONSEQUENCE],
-            },
-          ],
-        },
-        rulesEngineOptions,
-      ).execute({
-        events: {
-          '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
-            {
-              timestamps: [1681321319855],
-            },
-        },
-      }),
-    ).toEqual([]);
-  });
-
-  it("should return  in case count of an event is greater than one and the event is in the date range for ordered search type", () => {
-    expect(
-      RulesEngine(
-        {
-          version: 1,
-          rules: [
-            {
-              condition: {
-                definition: {
-                  conditions: [
-                    {
-                      definition: {
-                        conditions: [
-                          {
-                            definition: {
-                              events: [
-                                {
-                                  "iam.eventType": "display",
-                                  "iam.id":
-                                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
-                                },
-                                {
-                                  "iam.eventType": "interact",
-                                  "iam.id":
-                                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
-                                },
-                              ],
-                              matcher: "ge",
-                              value: 1,
-                              from: 1681321309855,
-                              to: 1996681309855,
-                              searchType: "ordered",
-                            },
-                            type: "historical",
-                          },
-                        ],
-                        logic: "and",
-                      },
-                      type: "group",
-                    },
-                  ],
-                  logic: "and",
-                },
-                type: "group",
-              },
-              consequences: [CONSEQUENCE],
-            },
-          ],
-        },
-        rulesEngineOptions,
-      ).execute({
-        events: {
-          '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
-            {
-              timestamps: [1681321319855],
-            },
-          '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb","eventType":"interact"}':
-            {
-              timestamps: [1681321319855],
-            },
-        },
-      }),
-    ).toEqual([[CONSEQUENCE]]);
-  });
-
-  it("Should return 0 if the count for any event is ever zero for ordered search type", () => {
-    expect(
-      RulesEngine(
-        {
-          version: 1,
-          rules: [
-            {
-              condition: {
-                definition: {
-                  conditions: [
-                    {
-                      definition: {
-                        conditions: [
-                          {
-                            definition: {
-                              events: [
-                                {
-                                  "iam.eventType": "display",
-                                  "iam.id":
-                                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
-                                },
-                                {
-                                  "iam.eventType": "interact",
-                                  "iam.id":
-                                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
-                                },
-                              ],
-                              matcher: "eq",
-                              value: 1,
-                              from: 1681321309855,
-                              to: 1996681309855,
-                              searchType: "ordered",
-                            },
-                            type: "historical",
-                          },
-                        ],
-                        logic: "and",
-                      },
-                      type: "group",
-                    },
-                  ],
-                  logic: "and",
-                },
-                type: "group",
-              },
-              consequences: [CONSEQUENCE],
-            },
-          ],
-        },
-        rulesEngineOptions,
-      ).execute({
-        events: {
-          display: {
-            "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa":
-              {
-                event: {
-                  "iam.eventType": "display",
-                  "iam.id":
-                    "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
-                },
-                timestamp: 1681321319855,
-                count: 1,
-              },
-          },
-        },
-      }),
-    ).toEqual([]);
-  });
-
-  it("distinguishes between display and interact events with the same id", () => {
-    const displayRuleset = {
-      version: 1,
-      rules: [
-        {
-          condition: {
-            definition: {
-              conditions: [
-                {
+                condition: {
                   definition: {
                     conditions: [
                       {
                         definition: {
-                          events: [
+                          conditions: [
                             {
-                              "iam.eventType": "display",
-                              "iam.id": "6cd5a8ed",
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 0,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                              },
+                              type: "historical",
                             },
                           ],
-                          matcher: "ge",
-                          value: 1,
+                          logic: "and",
                         },
-                        type: "historical",
+                        type: "group",
                       },
                     ],
                     logic: "and",
                   },
                   type: "group",
                 },
-              ],
-              logic: "and",
-            },
-            type: "group",
+                consequences: [CONSEQUENCE],
+              },
+            ],
           },
-          consequences: [CONSEQUENCE],
-        },
-      ],
-    };
-
-    const interactRuleset: RuleSet = {
-      version: 1,
-      rules: [
-        {
-          condition: {
-            definition: {
-              conditions: [
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            display: {
+              "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6":
                 {
+                  event: {
+                    "iam.eventType": "display",
+                    "iam.id":
+                      "28bea011-e596-4429-b8f7-b5bd630c6743#b45498cb-96d1-417a-81eb-2f09157ad8c6",
+                  },
+                  firstTimestamp: 1695065771698,
+                  timestamp: 1695065771698,
+                  count: 0,
+                },
+            },
+          },
+        }),
+      ).toEqual([[CONSEQUENCE]]);
+    });
+
+    it("should return empty consequence for historical condition when count doesn't match with matcher provided", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
                   definition: {
                     conditions: [
                       {
                         definition: {
-                          events: [
+                          conditions: [
                             {
-                              "iam.eventType": "interact",
-                              "iam.id": "6cd5a8ed",
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 0,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                              },
+                              type: "historical",
                             },
                           ],
-                          matcher: "ge",
-                          value: 1,
+                          logic: "and",
                         },
-                        type: "historical",
+                        type: "group",
                       },
                     ],
                     logic: "and",
                   },
                   type: "group",
                 },
-              ],
-              logic: "and",
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
+              {
+                timestamps: [1681321319855],
+              },
+          },
+        }),
+      ).toEqual([]);
+    });
+
+    it("distinguishes between display and interact events with the same id", () => {
+      const displayRuleset = {
+        version: 1,
+        rules: [
+          {
+            condition: {
+              definition: {
+                conditions: [
+                  {
+                    definition: {
+                      conditions: [
+                        {
+                          definition: {
+                            events: [
+                              {
+                                "iam.eventType": "display",
+                                "iam.id": "6cd5a8ed",
+                              },
+                            ],
+                            matcher: "ge",
+                            value: 1,
+                          },
+                          type: "historical",
+                        },
+                      ],
+                      logic: "and",
+                    },
+                    type: "group",
+                  },
+                ],
+                logic: "and",
+              },
+              type: "group",
             },
-            type: "group",
+            consequences: [CONSEQUENCE],
           },
-          consequences: [CONSEQUENCE],
-        },
-      ],
-    };
+        ],
+      };
 
-    expect(
-      RulesEngine(displayRuleset, rulesEngineOptions).execute({
-        events: {
-          '{"eventId":"6cd5a8ed","eventType":"interact"}': {
-            timestamps: [1681321939855],
+      const interactRuleset: RuleSet = {
+        version: 1,
+        rules: [
+          {
+            condition: {
+              definition: {
+                conditions: [
+                  {
+                    definition: {
+                      conditions: [
+                        {
+                          definition: {
+                            events: [
+                              {
+                                "iam.eventType": "interact",
+                                "iam.id": "6cd5a8ed",
+                              },
+                            ],
+                            matcher: "ge",
+                            value: 1,
+                          },
+                          type: "historical",
+                        },
+                      ],
+                      logic: "and",
+                    },
+                    type: "group",
+                  },
+                ],
+                logic: "and",
+              },
+              type: "group",
+            },
+            consequences: [CONSEQUENCE],
           },
-        },
-      }),
-    ).toEqual([]);
+        ],
+      };
 
-    expect(
-      RulesEngine(displayRuleset, rulesEngineOptions).execute({
-        events: {
-          '{"eventId":"6cd5a8ed","eventType":"display"}': {
-            timestamps: [1681321939855],
+      expect(
+        RulesEngine(displayRuleset, rulesEngineOptions).execute({
+          events: {
+            '{"eventId":"6cd5a8ed","eventType":"interact"}': {
+              timestamps: [1681321939855],
+            },
           },
-        },
-      }),
-    ).toEqual([[CONSEQUENCE]]);
+        }),
+      ).toEqual([]);
 
-    expect(
-      RulesEngine(interactRuleset, rulesEngineOptions).execute({
-        events: {
-          '{"eventId":"6cd5a8ed","eventType":"display"}': {
-            timestamps: [1681321939855],
+      expect(
+        RulesEngine(displayRuleset, rulesEngineOptions).execute({
+          events: {
+            '{"eventId":"6cd5a8ed","eventType":"display"}': {
+              timestamps: [1681321939855],
+            },
           },
-        },
-      }),
-    ).toEqual([]);
+        }),
+      ).toEqual([[CONSEQUENCE]]);
 
-    expect(
-      RulesEngine(interactRuleset, rulesEngineOptions).execute({
-        events: {
-          '{"eventId":"6cd5a8ed","eventType":"interact"}': {
-            timestamps: [1681321939855],
+      expect(
+        RulesEngine(interactRuleset, rulesEngineOptions).execute({
+          events: {
+            '{"eventId":"6cd5a8ed","eventType":"display"}': {
+              timestamps: [1681321939855],
+            },
           },
-        },
-      }),
-    ).toEqual([[CONSEQUENCE]]);
+        }),
+      ).toEqual([]);
+
+      expect(
+        RulesEngine(interactRuleset, rulesEngineOptions).execute({
+          events: {
+            '{"eventId":"6cd5a8ed","eventType":"interact"}': {
+              timestamps: [1681321939855],
+            },
+          },
+        }),
+      ).toEqual([[CONSEQUENCE]]);
+    });
+  });
+
+  describe("with searchType ordered", () => {
+    it("should return 1 for events that occured in the specified order", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
+                  definition: {
+                    conditions: [
+                      {
+                        definition: {
+                          conditions: [
+                            {
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                  {
+                                    "iam.eventType": "interact",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
+                                  },
+                                ],
+                                matcher: "ge",
+                                value: 1,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                                searchType: "ordered",
+                              },
+                              type: "historical",
+                            },
+                          ],
+                          logic: "and",
+                        },
+                        type: "group",
+                      },
+                    ],
+                    logic: "and",
+                  },
+                  type: "group",
+                },
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
+              {
+                timestamps: [1681321319855],
+              },
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb","eventType":"interact"}':
+              {
+                timestamps: [1681321319855],
+              },
+          },
+        }),
+      ).toEqual([[CONSEQUENCE]]);
+    });
+
+    it("Should return 0 for events the did not occured in the specified order", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
+                  definition: {
+                    conditions: [
+                      {
+                        definition: {
+                          conditions: [
+                            {
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                  {
+                                    "iam.eventType": "interact",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 1,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                                searchType: "ordered",
+                              },
+                              type: "historical",
+                            },
+                          ],
+                          logic: "and",
+                        },
+                        type: "group",
+                      },
+                    ],
+                    logic: "and",
+                  },
+                  type: "group",
+                },
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            display: {
+              "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa":
+                {
+                  event: {
+                    "iam.eventType": "display",
+                    "iam.id":
+                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                  },
+                  timestamp: 1681321319855,
+                  count: 1,
+                },
+            },
+          },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("with searchType mostRecent", () => {
+    it("Should return the index of the most recent event form a list of events", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
+                  definition: {
+                    conditions: [
+                      {
+                        definition: {
+                          conditions: [
+                            {
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                  {
+                                    "iam.eventType": "interact",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 1,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                                searchType: "mostRecent",
+                              },
+                              type: "historical",
+                            },
+                          ],
+                          logic: "and",
+                        },
+                        type: "group",
+                      },
+                    ],
+                    logic: "and",
+                  },
+                  type: "group",
+                },
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
+              {
+                timestamps: [1681321309855],
+              },
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb","eventType":"interact"}':
+              {
+                timestamps: [1681321309859],
+              },
+          },
+        }),
+      ).toEqual([[CONSEQUENCE]]);
+    });
+
+    it("Should return Infinity if no event is matching the given time range", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
+                  definition: {
+                    conditions: [
+                      {
+                        definition: {
+                          conditions: [
+                            {
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                  {
+                                    "iam.eventType": "interact",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 1,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                                searchType: "mostRecent",
+                              },
+                              type: "historical",
+                            },
+                          ],
+                          logic: "and",
+                        },
+                        type: "group",
+                      },
+                    ],
+                    logic: "and",
+                  },
+                  type: "group",
+                },
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa","eventType":"display"}':
+              {
+                timestamps: [1],
+              },
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb","eventType":"interact"}':
+              {
+                timestamps: [1],
+              },
+          },
+        }),
+      ).toEqual([]);
+    });
+
+    it("Should return Infinity if none of the provided events is inside the event history", () => {
+      expect(
+        RulesEngine(
+          {
+            version: 1,
+            rules: [
+              {
+                condition: {
+                  definition: {
+                    conditions: [
+                      {
+                        definition: {
+                          conditions: [
+                            {
+                              definition: {
+                                events: [
+                                  {
+                                    "iam.eventType": "display",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3aa",
+                                  },
+                                  {
+                                    "iam.eventType": "interact",
+                                    "iam.id":
+                                      "6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3bb",
+                                  },
+                                ],
+                                matcher: "eq",
+                                value: 1,
+                                from: 1681321309855,
+                                to: 1996681309855,
+                                searchType: "mostRecent",
+                              },
+                              type: "historical",
+                            },
+                          ],
+                          logic: "and",
+                        },
+                        type: "group",
+                      },
+                    ],
+                    logic: "and",
+                  },
+                  type: "group",
+                },
+                consequences: [CONSEQUENCE],
+              },
+            ],
+          },
+          rulesEngineOptions,
+        ).execute({
+          events: {
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3cc","eventType":"display"}':
+              {
+                timestamps: [1681321309855],
+              },
+            '{"eventId":"6cd5a8ed-e183-48b7-a0ef-657a4467df74#0477a309-6f63-4638-b729-ab51cf5dd3dd","eventType":"interact"}':
+              {
+                timestamps: [1681321309855],
+              },
+          },
+        }),
+      ).toEqual([]);
+    });
   });
 });

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -65,6 +65,9 @@ const RULE_SET_WITH_RULE_KEY: RuleSet = {
   rules: [
     {
       key: "rule1",
+      meta: {
+        ruleType: "card",
+      },
       condition: {
         definition: {
           key: "foo",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the new AJO disqualification feature, we need to support the new mostRecent search type. From a list of events, the mostRecent needs to return the index of the most recent event.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
